### PR TITLE
new implementation based on Richardson.jl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 1.2
+  - 1.4
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 1.4
+  - 1.2
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 Richardson = "708f8203-808e-40c0-ba2d-98a6953ed40d"
 
 [compat]
-julia = "1"
+julia = "1.4"
 Primes = "0.5"
 Richardson = "1.4"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,16 @@
 name = "Romberg"
 uuid = "ff01fdde-158c-414c-948f-c94b4a236685"
-authors = ["Forrest Gasdia"]
-version = "0.1.0"
+authors = ["Forrest Gasdia", "Steven G. Johnson"]
+version = "0.2.0"
 
 [deps]
-Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
+Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
+Richardson = "708f8203-808e-40c0-ba2d-98a6953ed40d"
 
 [compat]
 julia = "1"
+Primes = "0.5"
+Richardson = "1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,14 @@ authors = ["Forrest Gasdia", "Steven G. Johnson"]
 version = "0.2.0"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 Richardson = "708f8203-808e-40c0-ba2d-98a6953ed40d"
 
 [compat]
-julia = "1"
 Primes = "0.5"
 Richardson = "1.4"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 Richardson = "708f8203-808e-40c0-ba2d-98a6953ed40d"
 
 [compat]
-julia = "1.4"
+julia = "1"
 Primes = "0.5"
 Richardson = "1.4"
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ extrapolating back towards `Δx → 0`.   This works by factorizing `length(x) -
 and therefore works best when `length(x) - 1` has **many small factors**, ideally
 being a power of two.
 
-(In the even that `length(x) - 1` is prime, the `romberg` function is nearly
+(In the event that `length(x) - 1` is prime, the `romberg` function is nearly
 equivalent to the trapezoidal rule, since it extrapolates only from 2 points to
 `length(x)` points.)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ julia> @btime romberg($x, $y);
   515.078 ns (1 allocation: 192 bytes)
 ```
 
-So `romberg` is ~50% slower than `trapz`, but achieves nearly machine-precision accuracy,
+So `romberg` is ~30% slower than `trapz`, but achieves nearly machine-precision accuracy,
 ~12 digits more accurate than `trapz`. Even if 500 times as many samples of the
 function were to be used in `trapz`, it would still be ~7 digits less accurate than `romberg`.
 

--- a/README.md
+++ b/README.md
@@ -2,76 +2,35 @@
 
 [![Build Status](https://travis-ci.com/fgasdia/Romberg.jl.svg?branch=master)](https://travis-ci.com/fgasdia/Romberg.jl)
 
-**Note** [NumericalIntegration.jl](https://github.com/dextorious/NumericalIntegration.jl) offers a faster Romberg integration routine as `integrate(x, y, RombergEven())`. 
-
 A simple Julia package to perform Romberg integration over discrete 1-dimensional
 data.
 
 [Romberg integration](https://en.wikipedia.org/wiki/Romberg's_method) combines trapezoidal integration with Richardson extrapolation for improved accuracy. This package is
 meant to be used for integrating discrete data sampled with equal spacing. If
-your integrand is in functional form, then other methods are probably a better
-choice, e.g. [QuadGK.jl](https://github.com/JuliaMath/QuadGK.jl) or
-[HCubature.jl](https://github.com/JuliaMath/HCubature.jl), among others. Similarly,
-if you have discrete data sampled at _unequally_ spaced points, you will be limited
-to applying pure trapezoidal integration with [Trapz.jl](https://github.com/francescoalemanno/Trapz.jl).
+your integrand can be evaluated at arbitrary points, then other methods are probably a better
+choice, e.g. [QuadGK.jl](https://github.com/JuliaMath/QuadGK.jl). Similarly,
+if you have discrete data sampled at generic _unequally_ spaced points, you probably
+need to use a low-order method like [Trapz.jl](https://github.com/francescoalemanno/Trapz.jl).
 
 ## Usage
 
 First, install with
 
 ```jl
-]add https://github.com/fgasdia/Romberg.jl
+] add https://github.com/fgasdia/Romberg.jl
 ```
 
-Then, the interface is somewhat similar to `trapz`, except the primary function
-to call is `romberg`:
+The Romberg module exports a single function, `romberg(x,y)`, or alternatively `romberg(Δx,y)`,
+that returns a tuple `(I,E)` of the estimated integral `I` and a rough upper bound `E` on
+the error.
 ```jl
+using Romberg
+
 x = range(0, pi, length=2^8+1)
 y = sin.(x)
 
 romberg(x, y)
 ```
-
-By default, `romberg(x, y)` will use the maximum number of extrapolation steps
-possible given the length of `x`.
-
-If lower accuracy is acceptable or shorter compute time required, the number of
-extrapolation steps can be specified as an additional argument, up to
-`log2(prevpow(2, length(x)))`:
-```jl
-romberg(x, y, 6)
-```
-
-Finally, an in place form is available for filling in the entire triangular
-array formed by the Romberg integration. This can be used to analyze the
-convergence of the integration. The size of the mutable _square_ matrix argument
-`R` determines the number of extrapolation steps. If `size(R)` is `(L, L)`, then
-`L - 1` extrapolation steps are taken:
-```jl
-R = zeros(6, 6)
-romberg!(R, x, y)
-```
-gives the output
-```jl
-6×6 Array{Float64,2}:
- 1.92367e-16  0.0      0.0      0.0      0.0  0.0
- 1.5708       2.0944   0.0      0.0      0.0  0.0
- 1.89612      2.00456  1.99857  0.0      0.0  0.0
- 1.97423      2.00027  1.99998  2.00001  0.0  0.0
- 1.99357      2.00002  2.0      2.0      2.0  0.0
- 1.99839      2.0      2.0      2.0      2.0  2.0
-```
-
-The best estimate is the lower right corner of the matrix, accessible through
-linear indexing as
-```jl
-julia> R[end]
-2.0000000000013207
-```
-
-Note that the forms of `romberg` that do _not_ have the in place argument do not
-internally preallocate a full dense square array `R`. However, the same total number
-of mutations (allocations) must occur.
 
 ## Limitations
 
@@ -80,15 +39,20 @@ of mutations (allocations) must occur.
 Unlike [Trapz.jl](https://github.com/francescoalemanno/Trapz.jl), Romberg
 integration is a [Newton-Cotes](https://en.wikipedia.org/wiki/Newton%E2%80%93Cotes_formulas)
 formula which requires each element of `x` be equally spaced. This is indirectly
-enforced in `Romberg` by requiring `x::AbstractRange`.
+enforced in `Romberg` by requiring `x::AbstractRange`, or directly by passing the
+spacing `Δx` between points.
 
-### Most efficient if `length(x) - 1` is a power of 2
+### Most effective if `length(x) - 1` a power of 2
 
-The Romberg integration algorithm is coded assuming `ispow2(length(x) - 1) == true`.
-Therefore, `Romberg` is most efficient if these criteria can be met. However,
-`romberg(x,y)` can be used for `x` of any length at reduced accuracy and increased
-runtime. This works by applying Romberg integration piecewise across sections of
-`x` that do meet the criteria.
+Romberg integration works by recursively breaking the integral down into
+trapezoidal-rule evaluations using larger and larger spacings `Δx` and then
+extrapolating back towards `Δx → 0`.   This works by factorizing `length(x) - 1`,
+and therefore works best when `length(x) - 1` has **many small factors**, ideally
+being a power of two.
+
+(In the even that `length(x) - 1` is prime, the `romberg` function is nearly
+equivalent to the trapezoidal rule, since it extrapolates only from 2 points to
+`length(x)` points.)
 
 ### 1-dimensional
 
@@ -99,8 +63,9 @@ Currently `Romberg` only allows integration over a single dimension, so
 
 Given the limitations of `Romberg`, why use it over `Trapz`? For discrete
 samples of an underlying smooth function, Romberg integration can obtain
-_significantly higher accuracy_ estimates at relatively _low additional
+_significantly more accurate_ estimates at relatively _low additional
 computational cost_ over trapezoidal integration for a given number of samples.
+Moreover, unlike the trapezoidal rule, the `romberg` function also *returns an error estimate*.
 
 Here are some examples:
 
@@ -110,14 +75,14 @@ Here are some examples:
 
 ```jl
 using BenchmarkTools
-using Trapz
+using Trapz, Romberg
 
 x = range(0, π, length=2^6+1)
 y = sin.(x)
 exact_answer = 2
 
 tans = trapz(x, y)
-rans = romberg(x, y)
+rans, _ = romberg(x, y)
 ```
 
 ```jl
@@ -125,64 +90,20 @@ julia> exact_answer - tans
 0.0004016113599627502
 
 julia> exact_answer - rans
-1.3322676295501878e-15
+4.440892098500626e-16
 ```
 
 ```jl
-julia> b = @benchmarkable trapz($x, $y);
+julia> @btime trapz($x, $y);
+  340.834 ns (1 allocation: 96 bytes)
 
-julia> run(b)
-BenchmarkTools.Trial:
-  memory estimate:  96 bytes
-  allocs estimate:  1
-  --------------
-  minimum time:     276.000 ns (0.00% GC)
-  median time:      290.000 ns (0.00% GC)
-  mean time:        301.079 ns (0.00% GC)
-  maximum time:     20.295 μs (0.00% GC)
-  --------------
-  samples:          10000
-  evals/sample:     1
+julia> @btime romberg($x, $y);
+  515.078 ns (1 allocation: 192 bytes)
 ```
 
-```jl
-b = @benchmarkable romberg($x, $y);
-
-julia> run(b)
-BenchmarkTools.Trial:
-  memory estimate:  1.38 KiB
-  allocs estimate:  16
-  --------------
-  minimum time:     1.354 μs (0.00% GC)
-  median time:      1.415 μs (0.00% GC)
-  mean time:        1.587 μs (0.00% GC)
-  maximum time:     42.352 μs (0.00% GC)
-  --------------
-  samples:          10000
-  evals/sample:     1
-```
-
-```jl
-R = zeros(7, 7);
-b = @benchmarkable romberg!(r, $x, $y) setup=(r=copy($R))
-
-julia> run(b)
-BenchmarkTools.Trial:
-  memory estimate:  1.09 KiB
-  allocs estimate:  14
-  --------------
-  minimum time:     1.298 μs (0.00% GC)
-  median time:      1.348 μs (0.00% GC)
-  mean time:        1.439 μs (0.00% GC)
-  maximum time:     33.786 μs (0.00% GC)
-  --------------
-  samples:          10000
-  evals/sample:     1
-```
-
-So `romberg` is ~5× slower than `trapz`, but nearly at machine precision accuracy,
-~10 digits more accurate than `trapz`. Even if 5 times as many samples of the
-function are used in `trapz`, it's still ~8 digits accuracy behind the `romberg`.
+So `romberg` is ~50% slower than `trapz`, but achieves nearly machine-precision accuracy,
+~12 digits more accurate than `trapz`. Even if 500 times as many samples of the
+function were to be used in `trapz`, it would still be ~7 digits less accurate than `romberg`.
 
 ### 2)
 
@@ -194,7 +115,7 @@ y = x.^3
 exact_answer = 0.25
 
 tans = trapz(x, y)
-rans = romberg(x, y)
+rans, _ = romberg(x, y)
 ```
 
 ```jl
@@ -205,8 +126,9 @@ julia> exact_answer - rans
 0.0
 ```
 
-`romberg` was able to obtain the exact answer, compared to ~3 digits of accuracy
-for `trapz`, at the cost of ~7× the run time.
+`romberg` is able to obtain the exact answer (and in general is exact for polynomials
+of sufficiently low degree), compared to ~3 digits of accuracy
+for `trapz`, at the cost of ~2× the run time.
 
 ### 3)
 
@@ -220,7 +142,7 @@ y = sin.(m*x).*cos.(n*x)
 exact_answer = 2*m/(m^2 - n^2)
 
 tans = trapz(x, y)
-rans = romberg(x, y)
+rans, _ = romberg(x, y)
 ```
 
 ```jl
@@ -228,7 +150,7 @@ julia> exact_answer - tans
 0.0012075513578178043
 
 julia> exact_answer - rans
-6.515672331675049e-7
+-1.2385595582475872e-7
 ```
 
-`romberg` is ~4 digits better accuracy than `trapz` and ~5× the run time.
+`romberg` is ~4 digits better accuracy than `trapz` and ~50% greater run time.

--- a/src/Romberg.jl
+++ b/src/Romberg.jl
@@ -37,7 +37,7 @@ end
 
 function romberg(Δx::Real, y::AbstractVector; kws...)
     n = length(y)
-    endsum = n ≥ 2 ? (y[begin]+y[end])/2 : (n == 1 ? zero(y[1])/1 : zero(eltype(y))/1)
+    endsum = n ≥ 2 ? (first(y)+last(y))/2 : (n == 1 ? zero(first(y))/1 : zero(eltype(y))/1)
     n <= 2 && return endsum * Δx
     m = n - 1
     if ispow2(m)

--- a/src/Romberg.jl
+++ b/src/Romberg.jl
@@ -38,7 +38,7 @@ end
 function romberg(Δx::Real, y::AbstractVector; kws...)
     n = length(y)
     endsum = n ≥ 2 ? (first(y)+last(y))/2 : (n == 1 ? zero(first(y))/1 : zero(eltype(y))/1)
-    n <= 2 && return endsum * Δx
+    n <= 2 && return endsum * float(Δx)
     m = n - 1
     if ispow2(m)
         # fast path: no need to allocate factors array

--- a/src/Romberg.jl
+++ b/src/Romberg.jl
@@ -12,7 +12,7 @@ module Romberg
 
 export romberg
 
-import Primes, Richardson
+import Primes, Richardson, LinearAlgebra
 
 @views function _romberg(Δx, y, endsum, factors, numfactors; kws...)
     b, e = firstindex(y), lastindex(y)
@@ -39,7 +39,10 @@ function romberg(Δx::Real, y::AbstractVector; kws...)
     n = length(y)
     endsum = n ≥ 2 ? (first(y)+last(y))/2 : (n == 1 ? zero(first(y))/1 : zero(eltype(y))/1)
     Δxf = float(Δx)
-    n <= 2 && return (endsum * Δxf, zero(endsum) * Δxf)
+    if n <= 2
+        I = endsum * Δxf
+        return (I, LinearAlgebra.norm(I))
+    end
     m = n - 1
     if ispow2(m)
         # fast path: no need to allocate factors array

--- a/src/Romberg.jl
+++ b/src/Romberg.jl
@@ -24,7 +24,11 @@ import Primes, Richardson
         for k = 1:K
             step *= f
             sΔx = step*Δx
-            vals[i -= 1] = (sΔx * (sum(y[begin+step:step:end-step]) + endsum), sΔx)
+            if i == 2 # last iteration (empty sum)
+                vals[1] = (sΔx * endsum, sΔx)
+            else
+                vals[i -= 1] = (sΔx * (sum(y[begin+step:step:end-step]) + endsum), sΔx)
+            end
         end
     end
     return Richardson.extrapolate!(vals, power=2; kws...)

--- a/src/Romberg.jl
+++ b/src/Romberg.jl
@@ -22,7 +22,7 @@ import Primes, Richardson, LinearAlgebra
     vals[i] = v
     step = 1
     for (f,K) in factors
-        for k = 1:K
+        @inbounds for k = 1:K
             step *= f
             sΔx = step*Δx
             if i == 2 # last iteration (empty sum)

--- a/src/Romberg.jl
+++ b/src/Romberg.jl
@@ -15,7 +15,8 @@ export romberg
 import Primes, Richardson
 
 @views function _romberg(Δx, y, endsum, factors, numfactors; kws...)
-    v = (Δx * (sum(y[begin+1:end-1]) + endsum), Δx)
+    b, e = firstindex(y), lastindex(y)
+    v = (Δx * (sum(y[b+1:e-1]) + endsum), Δx)
     vals = Vector{typeof(v)}(undef, numfactors+1)
     i = numfactors+1
     vals[i] = v
@@ -27,7 +28,7 @@ import Primes, Richardson
             if i == 2 # last iteration (empty sum)
                 vals[1] = (sΔx * endsum, sΔx)
             else
-                vals[i -= 1] = (sΔx * (sum(y[begin+step:step:end-step]) + endsum), sΔx)
+                vals[i -= 1] = (sΔx * (sum(y[b+step:step:e-step]) + endsum), sΔx)
             end
         end
     end

--- a/src/Romberg.jl
+++ b/src/Romberg.jl
@@ -44,7 +44,7 @@ function romberg(Δx::Real, y::AbstractVector; kws...)
         end
         return _romberg(Δx, y, endsum, (2=>k,), k; kws...)
     else
-        factors = Primes.factor(n-1)
+        factors = Primes.factor(m)
         return _romberg(Δx, y, endsum, factors, sum(values(factors)); kws...)
     end
 end
@@ -62,8 +62,8 @@ to Richardson extrapolation of a trapezoidal rule to smaller and smaller `Δx`.
 The return value is a tuple `(I, E)` of the estimated integral `I` and
 an estimated upper bound `E` on the error in `I`.
 
-The algorithm is most effective if `length(x) == 2ⁿ + 1` for any positive integer
-`n`, but in general it can handle any non-prime `length(x) - 1`.  If `length(x) - 1`
+The algorithm is most effective if `length(x) - 1` has many small factors,
+ideally being a power of two, but it can handle any length.  If `length(x) - 1`
 is a prime number, it is nearly equivalent to the trapezoidal rule without extrapolation.
 
 # Examples

--- a/src/Romberg.jl
+++ b/src/Romberg.jl
@@ -42,10 +42,10 @@ function romberg(Δx::Real, y::AbstractVector; kws...)
             k += 1
             m >>= 1
         end
-        return _romberg(Δx, y, endsum, (2=>k,), k; kws...)
+        return _romberg(float(Δx), y, endsum, (2=>k,), k; kws...)
     else
         factors = Primes.factor(m)
-        return _romberg(Δx, y, endsum, factors, sum(values(factors)); kws...)
+        return _romberg(float(Δx), y, endsum, factors, sum(values(factors)); kws...)
     end
 end
 

--- a/src/Romberg.jl
+++ b/src/Romberg.jl
@@ -1,6 +1,6 @@
 """
-The `Romberg` module provides the functions `romberg` and `romberg!` that
-perform a Romberg integration of discrete 1-dimensional data `y` sampled at
+The `Romberg` module provides the function `romberg` that
+performs a Romberg integration of discrete 1-dimensional data `y` sampled at
 equally spaced points over `x`.
 
 Romberg integration combines the trapezoid method of integration with Richardson
@@ -10,23 +10,61 @@ slightly higher computational cost.
 """
 module Romberg
 
-using Trapz
+export romberg
 
-export romberg, romberg!
+import Primes, Richardson
 
-maxsteps(N) = trunc(Int, log2(prevpow(2, N)))
+@views function _romberg(Δx, y, endsum, factors, numfactors; kws...)
+    v = (Δx * (sum(y[begin+1:end-1]) + endsum), Δx)
+    vals = Vector{typeof(v)}(undef, numfactors+1)
+    i = numfactors+1
+    vals[i] = v
+    step = 1
+    for (f,K) in factors
+        for k = 1:K
+            step *= f
+            sΔx = step*Δx
+            vals[i -= 1] = (sΔx * (sum(y[begin+step:step:end-step]) + endsum), sΔx)
+        end
+    end
+    return Richardson.extrapolate!(vals, power=2; kws...)
+end
+
+function romberg(Δx::Real, y::AbstractVector; kws...)
+    n = length(y)
+    endsum = n ≥ 2 ? (y[begin]+y[end])/2 : (n == 1 ? zero(y[1])/1 : zero(eltype(y))/1)
+    n <= 2 && return endsum * Δx
+    m = n - 1
+    if ispow2(m)
+        # fast path: no need to allocate factors array
+        k = 0
+        while m > 1
+            k += 1
+            m >>= 1
+        end
+        return _romberg(Δx, y, endsum, (2=>k,), k; kws...)
+    else
+        factors = Primes.factor(n-1)
+        return _romberg(Δx, y, endsum, factors, sum(values(factors)); kws...)
+    end
+end
+
+romberg(x::AbstractRange, y::AbstractVector; kws...) = romberg(step(x), y; kws...)
 
 """
+    romberg(Δx::Real, y::AbstractVector)
     romberg(x::AbstractRange, y::AbstractVector)
 
-Integrate `y` sampled at `x` by Romberg integration applying the maximum possible
-number of Richardson extrapolation steps.
+Integrate `y` sampled at points with equal spacing `Δx`, or equivalently
+a range `x` (`Δx=step(x)`) by Romberg integration, which corresponds
+to Richardson extrapolation of a trapezoidal rule to smaller and smaller `Δx`.
 
-Romberg integration requires equally spaced points. This is enforced by
-requiring `x` to be an `AbstractRange`, rather than a dense vector.
+The return value is a tuple `(I, E)` of the estimated integral `I` and
+an estimated upper bound `E` on the error in `I`.
 
-The algorithm is most efficient if `length(x) == 2ⁿ + 1` for any positive integer
-`n`. However, the function will still work for any `length(x)`.
+The algorithm is most effective if `length(x) == 2ⁿ + 1` for any positive integer
+`n`, but in general it can handle any non-prime `length(x) - 1`.  If `length(x) - 1`
+is a prime number, it is nearly equivalent to the trapezoidal rule without extrapolation.
 
 # Examples
 
@@ -34,223 +72,9 @@ The algorithm is most efficient if `length(x) == 2ⁿ + 1` for any positive inte
 julia> x = range(0, π, length=2^8+1);
 
 julia> romberg(x, sin.(x))
-1.9999999999999996
+(2.0000000000000018, 1.9984014443252818e-15)
 ```
 """
-function romberg(x::AbstractRange{Tx}, y::AbstractVector{Ty}) where {Tx,Ty}
-    N = length(x)
-
-    # Integral over nothing
-    N <= 1 && return zero(promote_type(Tx,Ty))
-
-    @boundscheck begin
-        N == length(y) || throw(DimensionMismatch("length of `y` not equal to length of `x`"))
-
-        # NOTE: by requiring x::AbstractRange, a fixed step size is guaranteed
-    end
-
-    pN = prevpow(2, N-1) + 1
-    if pN == N
-        max_steps = maxsteps(N)
-        return integrate(x, y, max_steps)
-    else
-        return recursive_integration(x, y)
-    end
-end
-
-"""
-    romberg(x::AbstractRange, y::AbstractVector, max_steps::Integer)
-
-Integrate `y` sampled at `x` by Romberg integration applying `max_steps` of
-Richardson extrapolation.
-
-`max_steps` is the number of Richardson extrapolation steps applied (also equal
-to the number of trapezoid integrations - 1). In general, the larger it is, the
-lower error in the integration. The largest `max_steps` can be is
-`log2(prevpow(2, length(x)))`.
-
-When specifying `max_steps`, `length(x) - 1` must be a power of 2.
-
-# Examples
-
-```jldoctest
-julia> x = range(0, π, length=2^8+1);
-
-julia> romberg(x, sin.(x), 8)
-1.9999999999999996
-```
-
-```jldoctest
-julia> romberg(x, sin.(x), 9)
-ERROR: DomainError with 9:
-`max_steps` cannot exceed `log2(prevpow(2, length(x)))` = 8
-[...]
-```
-"""
-function romberg(x::AbstractRange{Tx}, y::AbstractVector{Ty}, max_steps::Integer) where {Tx,Ty}
-    N = length(x)
-
-    # Integral over nothing
-    N <= 1 && return zero(promote_type(Tx,Ty))
-
-    @boundscheck begin
-        max_steps <= maxsteps(N) || throw(DomainError(max_steps, "`max_steps` cannot exceed `log2(prevpow(2, length(x)))` = $(maxsteps(length(x)))"))
-        ispow2(N-1) || throw(DomainError(length(x), "`length(x) - 1` must be a power of 2"))
-        N == length(y) || throw(DimensionMismatch("length of `y` not equal to length of `x`"))
-
-        # NOTE: by requiring x::AbstractRange, a fixed step size is guaranteed
-    end
-
-    return integrate(x, y, max_steps)
-end
-
-"""
-    romberg!(R::AbstractMatrix, x::AbstractRange, y::AbstractVector)
-
-Integrate `y` sampled at `x` by Romberg integration, filling in the square
-matrix `R` in place.
-
-The size of `R` determines the number of Richardson extrapolation steps. If `R`
-has size 6×6, 5 extrapolation steps will be performed. In general, for a matrix
-with dimensions `L×L`, `max_steps` corresponds to `L - 1`.
-
-This function is useful to see how the Romberg integration progressed.
-
-# Examples
-
-```jldoctest
-julia> x = range(0, π, length=2^8+1);
-
-julia> R = zeros(4, 4);
-
-julia> romberg!(R, x, sin.(x))
-4×4 Array{Float64,2}:
- 1.92367e-16  0.0      0.0      0.0
- 1.5708       2.0944   0.0      0.0
- 1.89612      2.00456  1.99857  0.0
- 1.97423      2.00027  1.99998  2.00001
-```
-"""
-function romberg!(R::AbstractMatrix, x::AbstractRange, y::AbstractVector)
-    N = length(x)
-
-    N <= 1 && return fill!(R, 0)
-
-    @boundscheck begin
-        # Assume `size(R, 1)` is L (`max_steps + 1`)
-        size(R,1) <= maxsteps(N)+1 || throw(DomainError(size(R,1), "dimenensions of `R` cannot be greater than `log2(prevpow(2, length(x))) + 1`"))
-        isequal(size(R)...) || throw(DimensionMismatch("`R` must be square"))
-        N == length(y) || throw(DimensionMismatch("length of `y` not equal to length of `x`"))
-
-        # NOTE: by requiring x::AbstractRange, a fixed step size is guaranteed
-    end
-
-    integrate!(R, x, y)
-end
-
-function recursive_integration(x, y)
-    # Needed if `length(x) - 1` is not a power of 2
-
-    N = length(x)
-
-    N <= 1 && return zero(promote_type(x,y))
-
-    pN = prevpow(2, N-1) + 1
-
-    if pN == N
-        # `ispow2(N - 1) == true`
-        return integrate(x, y, maxsteps(N))
-    elseif pN < N
-        # `ispow2(N - 1) == false`
-        return integrate(x[1:pN], view(y,1:pN), maxsteps(pN)) + recursive_integration(x[pN:N], view(y,pN:N))
-    else
-        return trapz(x, y)
-    end
-end
-
-@inline function integrate(x::AbstractRange{Tx}, y::AbstractVector{Ty}, max_steps::Integer) where {Tx,Ty}
-    # `max_steps` are extrapolation steps, size of `R` is `max_steps + 1`
-    L = max_steps + 1
-
-    # `Rp` is "Rprevious", `Rc` is "Rcurrent"
-    Rp = Array{promote_type(Tx,Ty)}(undef, L)
-    Rc = similar(Rp)
-
-    trapezoid!(Rp, x, y)
-    extrapolate!(Rp, Rc)
-
-    # best estimate
-    return Rc[end]
-end
-
-@inline function integrate!(R::AbstractMatrix, x::AbstractRange, y::AbstractVector)
-    L = size(R, 1)
-
-    trapezoid!(view(R,:,1), x, y)
-    extrapolate!(R)
-
-    return R
-end
-
-@inline function trapezoid!(R, x, y)
-    N = length(x)
-    @inbounds for i in eachindex(R)
-        step_size = div(N-1, 2^(i-1))
-
-        if step_size == 0
-            # only triggered when N == 1?
-            idxs = 1:N-1:N
-        else
-            idxs = 1:step_size:N
-        end
-
-        R[i] = trapz(x[idxs], view(y,idxs))
-    end
-end
-
-@inline function extrapolate!(Rp, Rc)
-    L = length(Rp)
-    @inbounds for j = 2:L
-        # Precompute reused values
-        pow_prev = 4^(j-1)
-        den = inv(pow_prev - 1)
-
-        @inbounds for i = j:L
-            Rc[i] = (pow_prev*Rp[i] - Rp[i-1]) * den
-        end
-
-        # Only copying the relevant values! (not necessary on last loop)
-        if j < L
-            copyto!(Rp, j, Rc, j, L-j+1)
-        end
-    end
-end
-
-@inline function extrapolate!(R)
-    L = size(R,1)
-    @inbounds for j = 2:L
-        # Precompute reused values
-        pow_prev = 4^(j-1)
-        den = inv(pow_prev - 1)
-
-        @inbounds for i = j:L
-            R[i,j] = (pow_prev*R[i,j-1] - R[i-1,j-1]) * den
-        end
-    end
-end
-
-function error_test(R, max_steps)
-    # See http://www.sci.utah.edu/~beiwang/teaching/cs6210-fall-2016/lecture24.pdf
-
-    # The ratio of the difference between successive entries in column `j`
-    # should be approximately 4^j.
-
-    ratio = zeros(max_steps-2, max_steps-2)
-    for j = 1:max_steps-2
-        ratio[j:end,j] .= (R[1+j:end-1,j] - R[j:end-2,j]) ./ (R[2+j:end,j] - R[1+j:end-1,j])
-    end
-
-    return ratio
-end
+romberg
 
 end # module

--- a/src/Romberg.jl
+++ b/src/Romberg.jl
@@ -38,7 +38,8 @@ end
 function romberg(Δx::Real, y::AbstractVector; kws...)
     n = length(y)
     endsum = n ≥ 2 ? (first(y)+last(y))/2 : (n == 1 ? zero(first(y))/1 : zero(eltype(y))/1)
-    n <= 2 && return endsum * float(Δx)
+    Δxf = float(Δx)
+    n <= 2 && return (endsum * Δxf, zero(endsum) * Δxf)
     m = n - 1
     if ispow2(m)
         # fast path: no need to allocate factors array
@@ -47,10 +48,10 @@ function romberg(Δx::Real, y::AbstractVector; kws...)
             k += 1
             m >>= 1
         end
-        return _romberg(float(Δx), y, endsum, (2=>k,), k; kws...)
+        return _romberg(Δxf, y, endsum, (2=>k,), k; kws...)
     else
         factors = Primes.factor(m)
-        return _romberg(float(Δx), y, endsum, factors, sum(values(factors)); kws...)
+        return _romberg(Δxf, y, endsum, factors, sum(values(factors)); kws...)
     end
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,2 @@
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,4 +71,7 @@ using Romberg, Test
     x = range(1e-15, 1, length=2^16+1)
     y = log.(x)./(1 .+ x)
     @test romberg(x, y)[1] ≈ -π^2/12  atol=1e-4
+
+    # make sure it works for abstractly-typed y and integer Δx
+    @test romberg(1, Any[3,3,3,3,3,3,3])[1] == 6*3
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Romberg, LinearAlgebra, Test
+using Romberg, Test
 
 @testset "Romberg.jl" begin
     # Test interfaces
@@ -76,5 +76,5 @@ using Romberg, LinearAlgebra, Test
     @test romberg(1, Any[3,3,3,3,3,3,3])[1] == 6*3
 
     @test @inferred(romberg(1, [1//2, 1//4])) === (0.375, 0.375)
-    @test @inferred(romberg(1, [[1//2,1//1], [1//4,1//1]])) == ([0.375,1.0], norm([0.375,1.0]))
+    @test @inferred(romberg(1, [[1//2,1//1], [1//4,1//1]])) == ([0.375,1.0], hypot(0.375,1.0))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,4 +74,6 @@ using Romberg, Test
 
     # make sure it works for abstractly-typed y and integer Δx
     @test romberg(1, Any[3,3,3,3,3,3,3])[1] == 6*3
+
+    @test @inferred(romberg(1, [1//2, 1//4])) === (0.375, 0.0)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,74 +1,74 @@
-using Romberg
-using Test
-using Trapz
+using Romberg, Test
 
 @testset "Romberg.jl" begin
     # Test interfaces
     x = range(0, π, length=2^8+1)
     y = sin.(x)
 
-    @test romberg(x, y) == romberg(x, y, 8)
-
-    max_steps = 7
-    R = zeros(max_steps+1, max_steps+1)
-    @test romberg!(R, x, y)[end] == romberg(x, y, max_steps)
+    @test romberg(x, y) == romberg(x, y, maxeval=8)
 
     # Test ispow2(length(x) - 1) == false
     x = range(0, π, length=2^8)
     y = sin.(x)
-    @test romberg(x, y) ≈ 2
+    @test romberg(x, y)[1] ≈ 2   rtol=1e-12
 
     x = range(0, π, length=2^8-1)
     y = sin.(x)
-    @test romberg(x, y) ≈ 2
-
-    # Test `max_steps` too large
-    @test_throws DomainError romberg(x, y, 9)
+    @test romberg(x, y)[1] ≈ 2   rtol=1e-9
 
     # Test length(x) == 1
     x = 0:0
     y = sin.(x)
-    R = zeros(1, 1)
-    @test romberg(x, y) == 0
-    @test romberg!(R, x, y) == zeros(1,1)
+    @test romberg(x, y)[1] == 0
 
     # Test length(x) == 2
     x = range(0, 1, length=2)
     y = x.^2
-    @test romberg(x,y) ≈ trapz(x, y)  # integration is inaccurate
+    @test romberg(x,y)[1] == 0.5   # integration is inaccurate
 
     # Test length(x) == 3
     x = range(0, 1, length=3)
     y = x.^2
-    @test romberg(x, y) ≈ 1/3
+    @test romberg(x, y)[1] ≈ 1/3   rtol=3e-16  # should be exact up to roundoff error
 
     # Integrate different functions
     x = range(0, π, length=2^8+1)
     y = sin.(x)
-    @test romberg(x, y) ≈ 2
+    @test romberg(x, y)[1] ≈ 2    rtol=1e-15
 
     x = range(0, 1, length=2^8+1)
     y = x.^3
-    @test romberg(x, y) ≈ 1/4
+    @test romberg(x, y)[1] ≈ 1/4   rtol=3e-16  # should be exact up to roundoff error
 
     x = range(0, π/2, length=2^5+1)
     y = sin.(x).^2
-    @test romberg(x, y) ≈ π/4
+    @test romberg(x, y)[1] ≈ π/4    rtol=1e-15
 
     m = 3
     n = 4
     x = range(0, π, length=2^8+1)
     y = sin.(m*x).*cos.(n*x)
-    @test romberg(x, y) ≈ 2*m/(m^2 - n^2)
+    v = romberg(x, y)
+    @test v[1] ≈ 2*m/(m^2 - n^2)  rtol=1e-13
+    @test v[2] < 1e-10
+
+    # the following are singular integrands where the underlying
+    # theory of Romberg integration starts to break down:
 
     # this one requires lots of samples...
     a = 15
     x = range(0, a, length=2^16+1)
     y = sqrt.(a^2 .- x.^2)
-    @test romberg(x, y) ≈ π*a^2/4
+    @test romberg(x, y)[1] ≈ π*a^2/4   rtol=1e-8
+    # we can do much better if we put in the correct convergence
+    # rate for this singular integrand, but this requires some
+    # understanding of the theory that most people won't have…
+    x = range(0, a, length=2^7+1)
+    y = sqrt.(a^2 .- x.^2)
+    @test romberg(x, y, power=0.5)[1] ≈ π*a^2/4   rtol=1e-8
 
     # tricky to integrate
     x = range(1e-15, 1, length=2^16+1)
     y = log.(x)./(1 .+ x)
-    @test romberg(x, y) ≈ -π^2/12 atol=1e-4
+    @test romberg(x, y)[1] ≈ -π^2/12  atol=1e-4
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Romberg, Test
+using Romberg, LinearAlgebra, Test
 
 @testset "Romberg.jl" begin
     # Test interfaces
@@ -75,5 +75,6 @@ using Romberg, Test
     # make sure it works for abstractly-typed y and integer Δx
     @test romberg(1, Any[3,3,3,3,3,3,3])[1] == 6*3
 
-    @test @inferred(romberg(1, [1//2, 1//4])) === (0.375, 0.0)
+    @test @inferred(romberg(1, [1//2, 1//4])) === (0.375, 0.375)
+    @test @inferred(romberg(1, [[1//2,1//1], [1//4,1//1]])) == ([0.375,1.0], norm([0.375,1.0]))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Romberg, Test
     x = range(0, π, length=2^8+1)
     y = sin.(x)
 
-    @test romberg(x, y) == romberg(x, y, maxeval=8)
+    @test romberg(x, y) == romberg(x, y, maxeval=9)
 
     # Test ispow2(length(x) - 1) == false
     x = range(0, π, length=2^8)


### PR DESCRIPTION
Fixes #3, replacing the implementation with a new one based on Richardson.jl.  (Requires Richardson.jl version 1.4 for the new `extrapolate!` function, in order to bring the allocations down to 1: JuliaRegistries/General#26385)

The performance now seems to be mostly within about 50% of `trapz` and NumericalIntegration.jl in the common case where the length is 1 + power-of-two.

It handles non-power of two sizes by performing Richardson extrapolation based on the general factorization of `length(y)-1`.

Your previous approach of breaking it down recursively into the sum of two integrals could potentially have much lower-order accuracy, I think, if the length of one of the two integrals is so small that it ends up being equivalent to the trapezoidal rule — the accuracy is limited by the accuracy of the *least-accurate* piece of the integral, so it doesn't seem like it will help much to use a much more accurate method for only *part* of the integral.  The new approach obtains trapezoidal-rule accuracy only in the case where `length(y)-1` is prime, though it is most accurate when `length(y)-1` has many small factors.   (In principle, you might be able to do better in the prime case by breaking `length(y)-1` into the sum of two highly composite sizes, but I'm not sure of a good way to do this.)

I eliminated the `romberg!` function since it doesn't seem like one saves that much anymore by pre-allocating, although in principle one could add something like this back to pre-allocate the `vals` array in `_romberg`.    You can also pass keyword arguments, like tolerances and maximum numbers of extrapolation steps, through to the underlying `Richardson.extrapolate!` function, but I didn't document them since it's not clear how useful they would be to most people.  The Richardson package already adaptively picks the number of extrapolation steps to use based on its error estimate.